### PR TITLE
Out of range bug fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "known_extents_list_view_builder",
+            "request": "launch",
+            "type": "dart",
+            "program": "./example/lib/example.dart"
+        },
+        {
+            "name": "known_extents_list_view_builder (profile mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        }
+    ]
+}

--- a/lib/render_sliver_known_extents_list.dart
+++ b/lib/render_sliver_known_extents_list.dart
@@ -55,6 +55,12 @@ abstract class RenderSliverKnownExtentsBoxAdaptor
   /// layout offset zero.
   @protected
   double indexToLayoutOffset(List<double> itemHeights, int index) {
+    if (index < 0) {
+      return 0;
+    }
+    if (index >= itemHeights.length) {
+      return itemHeights.last;
+    }
     return itemHeights[index];
   }
 
@@ -172,10 +178,18 @@ abstract class RenderSliverKnownExtentsBoxAdaptor
     assert(remainingExtent >= 0.0);
     final double targetEndScrollOffset = scrollOffset + remainingExtent;
 
-    BoxConstraints childConstraints(int index) => constraints.asBoxConstraints(
-          minExtent: itemExtents[index],
-          maxExtent: itemExtents[index],
+    BoxConstraints childConstraints(int index) {
+      if (index < 0 || index >= itemExtents.length) {
+        return constraints.asBoxConstraints(
+          minExtent: 0.0,
+          maxExtent: 0.0,
         );
+      }
+      return constraints.asBoxConstraints(
+        minExtent: itemExtents[index],
+        maxExtent: itemExtents[index],
+      );
+    }
 
     final int firstIndex =
         getMinChildIndexForScrollOffset(scrollOffset, itemHeights);


### PR DESCRIPTION
closes #3 

Flutter checks for constraints of list items that are out of range, this provides a default rather than erroring. Fixes crash that would occur when reordering while scrolled to the bottom of the list.