### PR TITLE
_itemHeights must be updated when _itemExtents has changed.

### DIFF
--- a/lib/render_sliver_known_extents_list.dart
+++ b/lib/render_sliver_known_extents_list.dart
@@ -385,6 +385,7 @@ class RenderSliverKnownExtentsList extends RenderSliverKnownExtentsBoxAdaptor {
   set itemExtents(List<double> value) {
     if (_itemExtents == value) return;
     _itemExtents = value;
+    _itemHeights = _makeHeights(value);
     markNeedsLayout();
   }
 }


### PR DESCRIPTION
_itemHeights must be updated when _itemExtents has changed. Otherwise, it won't update the item height even though it has changed afterward.