### PR TITLE
Rebuilds sliver list when extents change inside plain list.

### DIFF
--- a/lib/known_extents_list_view_builder.dart
+++ b/lib/known_extents_list_view_builder.dart
@@ -55,6 +55,7 @@ class KnownExtentsListView extends BoxScrollView {
   @override
   Widget buildChildLayout(BuildContext context) {
     return SliverKnownExtentsList(
+      key: ValueKey(itemExtents.hashCode),
       delegate: childrenDelegate,
       itemExtents: itemExtents,
     );


### PR DESCRIPTION
This was pushed up a while ago but not merged because there's a workaround pointed out to an issue writer... who unfortunately deleted his issue. But now there's a new PR addressing this issue